### PR TITLE
Ensure coefficient at t-1 is non-zero

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -126,11 +126,33 @@ function getRandomBytes(byteLength: number): Uint8Array {
   return crypto.getRandomValues(new Uint8Array(byteLength));
 }
 
+function getRandomByte(): number {
+  return getRandomBytes(1)[0]!;
+}
+
+function getNonZeroRandomByte(): number {
+  while (true) {
+    const byte = getRandomByte();
+    if (byte > 0) {
+      return byte;
+    }
+  }
+}
+
 // Creates a pseudo-random set of coefficients for a polynomial.
 function newCoefficients(intercept: number, degree: number): Readonly<Uint8Array> {
   const coefficients = new Uint8Array(degree + 1);
+
+  // The first byte is always the intercept
   coefficients[0] = intercept;
-  coefficients.set(getRandomBytes(degree), 1);
+
+  for (let i = 1; i <= degree; i++) {
+    // degree is equal to t-1, where t is the threshold of required shares.
+    // The coefficient at t-1 cannot equal 0.
+    const coefficientTMinus1 = i === degree;
+    coefficients[i] = coefficientTMinus1 ? getNonZeroRandomByte() : getRandomByte();
+  }
+
   return coefficients;
 }
 


### PR DESCRIPTION
Address PVY-01-002. See [the audit](https://cure53.de/audit-report_privy-sss-library.pdf) for a detailed description.

Specifically:

> The function newCoefficients that implements the generation of the coefficients of the polynomial f fails to check that the coefficient at−1 is not a zero, which might result in incorrect instantiations of a (t,n)-threshold scheme.