### PR TITLE
Reject secret polynomial evaluation at zero

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -131,7 +131,7 @@ function interpolatePolynomial(xSamples: Uint8Array, ySamples: Uint8Array, x: nu
 // Evaluates a polynomial with the given x using Horner's method.
 function evaluate(coefficients: Uint8Array, x: number, degree: number) {
   if (x === 0) {
-    return coefficients[0]!;
+    throw new Error('cannot evaluate secret polynomial at zero')
   }
 
   let result = coefficients[degree]!;


### PR DESCRIPTION
Evaluating the secret polynomial at zero immediately reveals the secret. Currently, the Horner evaluator will do this if zero is passed in during share computation (and in fact has it as a special case). While such an evaluation can't happen now, this PR replaces the evaluation edge case with an error to mitigate future risk.