### PR TITLE
Remove unnecessary index shuffling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -174,31 +174,6 @@ function newCoefficients(intercept: number, degree: number): Readonly<Uint8Array
   return coefficients;
 }
 
-// Creates a set of values from [1, 256).
-// Returns a psuedo-random shuffling of the set.
-function newCoordinates(): Readonly<Uint8Array> {
-  const coordinates = new Uint8Array(255);
-  for (let i = 0; i < 255; i++) {
-    coordinates[i] = i + 1;
-  }
-
-  // Pseudo-randomize the array of coordinates.
-  //
-  // This impl maps almost perfectly because both of the lists (coordinates and randomIndices)
-  // have a length of 255 and byte values are between 0 and 255 inclusive. The only value that
-  // does not map neatly here is if the random byte is 255, since that value used as an index
-  // would be out of bounds. Thus, for bytes whose value is 255, wrap around to 0.
-  const randomIndices = getRandomBytes(255);
-  for (let i = 0; i < 255; i++) {
-    const j = randomIndices[i]! % 255; // Make sure to handle the case where the byte is 255.
-    const temp = coordinates[i]!;
-    coordinates[i] = coordinates[j]!;
-    coordinates[j] = temp;
-  }
-
-  return coordinates;
-}
-
 // Helpers for declarative argument validation.
 const AssertArgument = {
   instanceOf(object: any, constructor: Function, message: string) {
@@ -256,11 +231,10 @@ export async function split(
 
   const result: Uint8Array[] = [];
   const secretLength = secret.byteLength;
-  const xCoordinates = newCoordinates();
 
   for (let i = 0; i < shares; i++) {
     const share = new Uint8Array(secretLength + 1);
-    share[secretLength] = xCoordinates[i]!;
+    share[secretLength] = i + 1;
     result.push(share);
   }
 
@@ -271,8 +245,7 @@ export async function split(
     const coefficients = newCoefficients(byte, degree);
 
     for (let j = 0; j < shares; ++j) {
-      const x = xCoordinates[j]!;
-      const y = evaluate(coefficients, x, degree);
+      const y = evaluate(coefficients, j + 1, degree);
       result[j]![i] = y;
     }
   }


### PR DESCRIPTION
The implementation currently produces share indexes by shuffling an ordered index list. This shuffling is unnecessary, since the security of the design does not require such a distribution of share indexes. Further, the shuffling method used is [biased](https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#Na%C3%AFve_method), which was presumably not intended.

This PR simplifies the design by removing the shuffling entirely and issuing shares in numerical order. The change also makes it much easier to assert that a zero-indexed share (which would reveal the secret) is never produced.