### PR TITLE
Remove leading coefficient restriction

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -144,19 +144,6 @@ function evaluate(coefficients: Uint8Array, x: number, degree: number) {
   return result;
 }
 
-function getRandomByte(): number {
-  return getRandomBytes(1)[0]!;
-}
-
-function getNonZeroRandomByte(): number {
-  while (true) {
-    const byte = getRandomByte();
-    if (byte > 0) {
-      return byte;
-    }
-  }
-}
-
 // Creates a pseudo-random set of coefficients for a polynomial.
 function newCoefficients(intercept: number, degree: number): Readonly<Uint8Array> {
   const coefficients = new Uint8Array(degree + 1);
@@ -164,12 +151,8 @@ function newCoefficients(intercept: number, degree: number): Readonly<Uint8Array
   // The first byte is always the intercept
   coefficients[0] = intercept;
 
-  for (let i = 1; i <= degree; i++) {
-    // degree is equal to t-1, where t is the threshold of required shares.
-    // The coefficient at t-1 cannot equal 0.
-    const coefficientTMinus1 = i === degree;
-    coefficients[i] = coefficientTMinus1 ? getNonZeroRandomByte() : getRandomByte();
-  }
+  // All other coefficients are random
+  coefficients.set(getRandomBytes(degree), 1);
 
   return coefficients;
 }


### PR DESCRIPTION
Removes a restriction that the leading coefficient of a secret polynomial be nonzero, which breaks the security guarantee.

Closes #11.