### PR TITLE
Make it use as package in Node projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 node_modules/
 *.gitignored.*
 /*.d.ts
+!index.d.ts
 /*.js
 /*.js.map
 /esm/*.d.ts

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,7 @@
+export declare module "shamir-secret-sharing" {
+  export function split(
+    secret: Buffer,
+    options: { shares: number; threshold: number }
+  ): Buffer[];
+  export function combine(shares: Buffer[]): Buffer;
+}


### PR DESCRIPTION
## Description

I wanted to use this repository using `git`. So, I did this:
```sh
yarn add https://github.com/privy-io/shamir-secret-sharing\#c2220064546ee94c649b6113022a182ee0c49bc0
```

Then, found this issue:
```
No module found when I was trying to import this.
```

Hence, I added a `index.d.ts` file at the root to enable easy importing like this:
```ts
import { split, combine } from "shamir-secret-sharing";
```

## Key changes

- `index.d.ts` file added for easy import.
- `.gitignore` file modified to allow `index.d.ts` file stay in the repo/package.