### PR TITLE
Document biased shuffle

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -190,7 +190,10 @@ function newCoordinates(): Readonly<Uint8Array> {
   // would be out of bounds. Thus, for bytes whose value is 255, wrap around to 0.
   //
   // WARNING: This shuffle is biased and should NOT be used if an unbiased shuffle is required.
-  // This particular application does not require any shuffling, so it is not problematic here.
+  //
+  // However, Shamir-based secret sharing does not require any particular indexing (shuffled or
+  // not) for its security properties to hold; this means including the biased shuffle is not
+  // itself problematic here.
   const randomIndices = getRandomBytes(255);
   for (let i = 0; i < 255; i++) {
     const j = randomIndices[i]! % 255; // Make sure to handle the case where the byte is 255.

--- a/src/index.ts
+++ b/src/index.ts
@@ -188,6 +188,9 @@ function newCoordinates(): Readonly<Uint8Array> {
   // have a length of 255 and byte values are between 0 and 255 inclusive. The only value that
   // does not map neatly here is if the random byte is 255, since that value used as an index
   // would be out of bounds. Thus, for bytes whose value is 255, wrap around to 0.
+  //
+  // WARNING: This shuffle is biased and should NOT be used if an unbiased shuffle is required.
+  // This particular application does not require any shuffling, so it is not problematic here.
   const randomIndices = getRandomBytes(255);
   for (let i = 0; i < 255; i++) {
     const j = randomIndices[i]! % 255; // Make sure to handle the case where the byte is 255.


### PR DESCRIPTION
The algorithm used for index shuffling is [biased](https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#Na%C3%AFve_method). This is not problematic here, since the shuffle is unnecessary and has no impact on security. However, it should not be used anywhere where an unbiased shuffle is required.

This PR adds documentation to avoid the case where the code is used elsewhere in a dangerous way.