### PR TITLE
feat: add synchronous split and combine APIs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -218,11 +218,7 @@ const AssertArgument = {
  * @param threshold The minimum number of shares required to reconstruct `secret`. Must be at least 2 and at most 255.
  * @returns A list of `shares` shares.
  */
-export async function split(
-  secret: Uint8Array,
-  shares: number,
-  threshold: number,
-): Promise<Uint8Array[]> {
+export function splitSync(secret: Uint8Array, shares: number, threshold: number): Uint8Array[] {
   // secret must be a non-empty Uint8Array
   AssertArgument.instanceOf(secret, Uint8Array, 'secret must be a Uint8Array');
   AssertArgument.greaterThanOrEqualTo(secret.byteLength, 1, 'secret cannot be empty');
@@ -270,7 +266,7 @@ export async function split(
  * @param shares A list of shares to reconstruct the secret from. Must be at least 2 and at most 255.
  * @returns The reconstructed secret.
  */
-export async function combine(shares: Uint8Array[]): Promise<Uint8Array> {
+export function combineSync(shares: Uint8Array[]): Uint8Array {
   // Shares must be an array with length in the range [2, 256)
   AssertArgument.instanceOf(shares, Array, 'shares must be an Array');
   AssertArgument.inRange(
@@ -329,4 +325,30 @@ export async function combine(shares: Uint8Array[]): Promise<Uint8Array> {
   }
 
   return secret;
+}
+
+/**
+ * Splits a `secret` into `shares` number of shares, requiring `threshold` of them to reconstruct `secret`.
+ *
+ * @param secret The secret value to split into shares.
+ * @param shares The total number of shares to split `secret` into. Must be at least 2 and at most 255.
+ * @param threshold The minimum number of shares required to reconstruct `secret`. Must be at least 2 and at most 255.
+ * @returns A promise that resolves to a list of `shares` shares.
+ */
+export async function split(
+  secret: Uint8Array,
+  shares: number,
+  threshold: number,
+): Promise<Uint8Array[]> {
+  return splitSync(secret, shares, threshold);
+}
+
+/**
+ * Combines `shares` to reconstruct the secret.
+ *
+ * @param shares A list of shares to reconstruct the secret from. Must be at least 2 and at most 255.
+ * @returns A promise that resolves to the reconstructed secret.
+ */
+export async function combine(shares: Uint8Array[]): Promise<Uint8Array> {
+  return combineSync(shares);
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,4 +1,4 @@
-const {split, combine} = require('../');
+const {split, splitSync, combine, combineSync} = require('../');
 
 describe('shamir-secret-sharing', () => {
   const secret = new Uint8Array([0x73, 0x65, 0x63, 0x72, 0x65, 0x74]);
@@ -76,6 +76,16 @@ describe('shamir-secret-sharing', () => {
     await expect(shareDuplicates).rejects.toThrow(
       new TypeError('shares must contain unique values but a duplicate was found'),
     );
+  });
+
+  it('can split and combine synchronously', () => {
+    const shares = splitSync(secret, 3, 2);
+    expect(shares).toHaveLength(3);
+    expect(shares[0]).toBeInstanceOf(Uint8Array);
+    expect(shares[0].byteLength).toBe(secret.byteLength + 1);
+
+    const reconstructed = combineSync([shares[0], shares[2]]);
+    expect(reconstructed).toEqual(secret);
   });
 
   it('can split a secret into multiple shares', async () => {


### PR DESCRIPTION
Adds synchronous `splitSync` and `combineSync` APIs while keeping the existing async `split` and `combine` exports as wrappers.

The core work is already synchronous, including random byte generation, so this gives consumers a direct sync path without breaking the current Promise-based API.

Changed:
- extracted the existing split logic into `splitSync`
- extracted the existing combine logic into `combineSync`
- kept `split` and `combine` backward-compatible
- added coverage for the synchronous API path

Closes #35

Checked with:
- `npm test`
- `npm run lint`
- `git diff --check`
